### PR TITLE
fix: keyboard not popping up after dismiss

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -32,71 +32,62 @@ yarn add react-native-otp-entry
 1. Import the `OTPInput` component from `react-native-otp-entry`:
 
    ```javascript
-   import { OTPInput } from 'react-native-otp-entry';
+   import { OTPInput } from "react-native-otp-entry";
    ```
 
 2. Render the `OTPInputView` component in your screen/component:
 
    ```jsx
-   <OtpInput 
-        numberOfDigits={6}
-        onTextChange={(text) => console.log(text)}
-   />
+   <OtpInput numberOfDigits={6} onTextChange={(text) => console.log(text)} />
    ```
 
 3. Customize the styling as per your requirements:
 
    ```javascript
-    <OTPInput
-        numberOfDigits={6}
-        focusColor="green"
-        onTextChange={text => console.log(text)}
-        containerStyle={styles.container}
-        inputsContainerStyle={styles.inputsContainer}
-        pinCodeContainerStyle={styles.pinCodeContainer}
-        pinCodeTextStyle={styles.pinCodeText}
-        focusStickStyle={styles.focusStick}
-        focusStickBlinkingDuration={500}
-    />
+   <OTPInput
+     numberOfDigits={6}
+     focusColor="green"
+     onTextChange={(text) => console.log(text)}
+     containerStyle={styles.container}
+     inputsContainerStyle={styles.inputsContainer}
+     pinCodeContainerStyle={styles.pinCodeContainer}
+     pinCodeTextStyle={styles.pinCodeText}
+     focusStickStyle={styles.focusStick}
+     focusStickBlinkingDuration={500}
+   />
    ```
-
-
 
 ## Props
 
 The `react-native-otp-entry` component accepts the following props:
 
-| Prop                           | Type                            | Description                                                                                                                                       |
-| ------------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `numberOfDigits`               | number                          | The number of digits to be displayed in the OTP entry.                                                                                            |
-| `focusColor`                   | ColorValue                      | The color of the input field border and stick when it is focused.                                                                                                  |
-| `onTextChange`                 | (text: string) => void          | A callback function that is invoked when the OTP text changes. It receives the updated text as an argument.                                        |
-| `theme`               | Theme                       | Custom styles for each element.                                                                                         |
-| `focusStickBlinkingDuration`   | number                          | The duration (in milliseconds) for the focus stick to blink.                                                     |
+| Prop                         | Type                   | Description                                                                                                 |
+| ---------------------------- | ---------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `numberOfDigits`             | number                 | The number of digits to be displayed in the OTP entry.                                                      |
+| `focusColor`                 | ColorValue             | The color of the input field border and stick when it is focused.                                           |
+| `onTextChange`               | (text: string) => void | A callback function that is invoked when the OTP text changes. It receives the updated text as an argument. |
+| `hideStick`                  | boolean                | Hide cursor of the focused input.                                                                           |
+| `theme`                      | Theme                  | Custom styles for each element.                                                                             |
+| `focusStickBlinkingDuration` | number                 | The duration (in milliseconds) for the focus stick to blink.                                                |
 
-
-
-| Theme                           | Type                            | Description                                                                                                                                       |
-| ------------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `containerStyle`               | ViewStyle                       | Custom styles for the root `View`.                                                                                         |
-| `inputsContainerStyle`         | ViewStyle                       | Custom styles for the container that holds the input fields.                                                                                      |
-| `pinCodeContainerStyle`        | ViewStyle                       | Custom styles for the container that wraps each individual digit in the OTP entry.                                                                |
-| `pinCodeTextStyle`             | TextStyle                       | Custom styles for the text within each individual digit in the OTP entry.                                                                         |
-| `focusStickStyle`              | ViewStyle                       | Custom styles for the focus stick, which indicates the focused input field.                                                                       |
+| Theme                   | Type      | Description                                                                        |
+| ----------------------- | --------- | ---------------------------------------------------------------------------------- |
+| `containerStyle`        | ViewStyle | Custom styles for the root `View`.                                                 |
+| `inputsContainerStyle`  | ViewStyle | Custom styles for the container that holds the input fields.                       |
+| `pinCodeContainerStyle` | ViewStyle | Custom styles for the container that wraps each individual digit in the OTP entry. |
+| `pinCodeTextStyle`      | TextStyle | Custom styles for the text within each individual digit in the OTP entry.          |
+| `focusStickStyle`       | ViewStyle | Custom styles for the focus stick, which indicates the focused input field.        |
 
 Note: The `ViewStyle` and `TextStyle` types are imported from `react-native` and represent the style objects used in React Native for views and text, respectively.
-
-
 
 ## Ref
 
 The `react-native-otp-entry` component exposes these functions with `ref`:
 
-| Prop                           | Type                            | Description                                                                                                                                       |
-| ------------------------------ | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `clear`               | () => void;                          |  Clears the value of the OTP input.                                                                                            |
-| `setValue`                   | (value: string) => void;                      | Sets the value of the OTP input.
-
+| Prop       | Type                     | Description                        |
+| ---------- | ------------------------ | ---------------------------------- |
+| `clear`    | () => void;              | Clears the value of the OTP input. |
+| `setValue` | (value: string) => void; | Sets the value of the OTP input.   |
 
 ## License
 

--- a/dist/OtpInput/OtpInput.js
+++ b/dist/OtpInput/OtpInput.js
@@ -3,12 +3,12 @@ Object.defineProperty(exports, "__esModule", { value: true });
 exports.OtpInput = void 0;
 const react_1 = require("react");
 const react_native_1 = require("react-native");
+const OtpInput_styles_1 = require("./OtpInput.styles");
 const VerticalStick_1 = require("./VerticalStick");
 const useOtpInput_1 = require("./useOtpInput");
-const OtpInput_styles_1 = require("./OtpInput.styles");
 exports.OtpInput = (0, react_1.forwardRef)((props, ref) => {
     const { models: { text, inputRef, focusedInputIndex }, actions: { clear, handlePress, handleTextChange }, forms: { setText }, } = (0, useOtpInput_1.useOtpInput)(props);
-    const { numberOfDigits, focusColor = "#A4D0A4", focusStickBlinkingDuration, theme = {}, } = props;
+    const { numberOfDigits, hideStick, focusColor = "#A4D0A4", focusStickBlinkingDuration, theme = {}, } = props;
     const { containerStyle, inputsContainerStyle, pinCodeContainerStyle, pinCodeTextStyle, focusStickStyle, } = theme;
     (0, react_1.useImperativeHandle)(ref, () => ({ clear, setValue: setText }));
     return (<react_native_1.View style={[OtpInput_styles_1.styles.container, containerStyle]}>
@@ -20,14 +20,10 @@ exports.OtpInput = (0, react_1.forwardRef)((props, ref) => {
             const isFocusedInput = index === focusedInputIndex;
             return (<react_native_1.Pressable key={`${char}-${index}`} onPress={handlePress} style={[
                     OtpInput_styles_1.styles.codeContainer,
-                    focusColor && isFocusedInput
-                        ? { borderColor: focusColor }
-                        : {},
+                    focusColor && isFocusedInput ? { borderColor: focusColor } : {},
                     pinCodeContainerStyle,
                 ]}>
-                {isFocusedInput ? (<VerticalStick_1.VerticalStick focusColor={focusColor} style={focusStickStyle} focusStickBlinkingDuration={focusStickBlinkingDuration}/>) : (<react_native_1.Text style={[OtpInput_styles_1.styles.codeText, pinCodeTextStyle]}>
-                    {char}
-                  </react_native_1.Text>)}
+                {isFocusedInput && !hideStick ? (<VerticalStick_1.VerticalStick focusColor={focusColor} style={focusStickStyle} focusStickBlinkingDuration={focusStickBlinkingDuration}/>) : (<react_native_1.Text style={[OtpInput_styles_1.styles.codeText, pinCodeTextStyle]}>{char}</react_native_1.Text>)}
               </react_native_1.Pressable>);
         })}
       </react_native_1.View>

--- a/dist/OtpInput/OtpInput.styles.d.ts
+++ b/dist/OtpInput/OtpInput.styles.d.ts
@@ -11,14 +11,13 @@ export declare const styles: {
         borderWidth: number;
         borderRadius: number;
         borderColor: string;
-        height: number;
-        width: number;
+        minHeight: number;
+        minWidth: number;
         justifyContent: "center";
         alignItems: "center";
     };
     codeText: {
         fontSize: number;
-        lineHeight: number;
     };
     hiddenInput: {
         width: number;

--- a/dist/OtpInput/OtpInput.styles.js
+++ b/dist/OtpInput/OtpInput.styles.js
@@ -15,14 +15,13 @@ exports.styles = react_native_1.StyleSheet.create({
         borderWidth: 1,
         borderRadius: 12,
         borderColor: "#DFDFDE",
-        height: 60,
-        width: 44,
+        minHeight: 60,
+        minWidth: 44,
         justifyContent: "center",
         alignItems: "center",
     },
     codeText: {
         fontSize: 28,
-        lineHeight: 38,
     },
     hiddenInput: {
         width: 1,

--- a/dist/OtpInput/OtpInput.types.d.ts
+++ b/dist/OtpInput/OtpInput.types.d.ts
@@ -3,6 +3,7 @@ export interface OtpInputProps {
     numberOfDigits: number;
     focusColor?: ColorValue;
     onTextChange?: (text: string) => void;
+    hideStick?: boolean;
     focusStickBlinkingDuration?: number;
     theme?: Theme;
 }

--- a/dist/OtpInput/useOtpInput.js
+++ b/dist/OtpInput/useOtpInput.js
@@ -2,11 +2,16 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.useOtpInput = void 0;
 const react_1 = require("react");
+const react_native_1 = require("react-native");
 const useOtpInput = ({ onTextChange }) => {
     const [text, setText] = (0, react_1.useState)("");
     const inputRef = (0, react_1.useRef)(null);
     const focusedInputIndex = text.length;
     const handlePress = () => {
+        // To fix bug when keyboard is not popping up after being dismissed
+        if (!react_native_1.Keyboard.isVisible()) {
+            react_native_1.Keyboard.dismiss();
+        }
         inputRef.current?.focus();
     };
     const handleTextChange = (value) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "react-native-otp-entry",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "react-native-otp-entry",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "MIT",
       "devDependencies": {
         "@types/react": "^18.2.12",

--- a/src/OtpInput/OtpInput.tsx
+++ b/src/OtpInput/OtpInput.tsx
@@ -1,9 +1,9 @@
-import { forwardRef, useImperativeHandle, useRef, useState } from "react";
+import { forwardRef, useImperativeHandle } from "react";
 import { Pressable, Text, TextInput, View } from "react-native";
-import { VerticalStick } from "./VerticalStick";
-import { OtpInputProps, OtpInputRef } from "./OtpInput.types";
-import { useOtpInput } from "./useOtpInput";
 import { styles } from "./OtpInput.styles";
+import { OtpInputProps, OtpInputRef } from "./OtpInput.types";
+import { VerticalStick } from "./VerticalStick";
+import { useOtpInput } from "./useOtpInput";
 
 export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props, ref) => {
   const {
@@ -13,6 +13,7 @@ export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props, ref) => {
   } = useOtpInput(props);
   const {
     numberOfDigits,
+    hideStick,
     focusColor = "#A4D0A4",
     focusStickBlinkingDuration,
     theme = {},
@@ -42,22 +43,18 @@ export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props, ref) => {
                 onPress={handlePress}
                 style={[
                   styles.codeContainer,
-                  focusColor && isFocusedInput
-                    ? { borderColor: focusColor }
-                    : {},
+                  focusColor && isFocusedInput ? { borderColor: focusColor } : {},
                   pinCodeContainerStyle,
                 ]}
               >
-                {isFocusedInput ? (
+                {isFocusedInput && !hideStick ? (
                   <VerticalStick
                     focusColor={focusColor}
                     style={focusStickStyle}
                     focusStickBlinkingDuration={focusStickBlinkingDuration}
                   />
                 ) : (
-                  <Text style={[styles.codeText, pinCodeTextStyle]}>
-                    {char}
-                  </Text>
+                  <Text style={[styles.codeText, pinCodeTextStyle]}>{char}</Text>
                 )}
               </Pressable>
             );

--- a/src/OtpInput/OtpInput.types.ts
+++ b/src/OtpInput/OtpInput.types.ts
@@ -4,6 +4,7 @@ export interface OtpInputProps {
   numberOfDigits: number;
   focusColor?: ColorValue;
   onTextChange?: (text: string) => void;
+  hideStick?: boolean;
   focusStickBlinkingDuration?: number;
   theme?: Theme;
 }

--- a/src/OtpInput/useOtpInput.ts
+++ b/src/OtpInput/useOtpInput.ts
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { TextInput } from "react-native";
+import { Keyboard, TextInput } from "react-native";
 import { OtpInputProps } from "./OtpInput.types";
 
 export const useOtpInput = ({ onTextChange }: OtpInputProps) => {
@@ -8,6 +8,10 @@ export const useOtpInput = ({ onTextChange }: OtpInputProps) => {
   const focusedInputIndex = text.length;
 
   const handlePress = () => {
+    // To fix bug when keyboard is not popping up after being dismissed
+    if (!Keyboard.isVisible()) {
+      Keyboard.dismiss();
+    }
     inputRef.current?.focus();
   };
 


### PR DESCRIPTION
## Closes #4 

# Solution
Dismiss `Keyboard` before showing if it's not visible, to ensure that it's closed

# Demo

https://github.com/anday013/react-native-otp-entry/assets/48630069/110253f0-b07d-42cb-9785-0818be56d43e

