### PR TITLE
feat: add `secureTextEntry` prop

### DIFF
--- a/dist/src/OtpInput/OtpInput.js
+++ b/dist/src/OtpInput/OtpInput.js
@@ -7,8 +7,8 @@ const OtpInput_styles_1 = require("./OtpInput.styles");
 const VerticalStick_1 = require("./VerticalStick");
 const useOtpInput_1 = require("./useOtpInput");
 exports.OtpInput = (0, react_1.forwardRef)((props, ref) => {
-    const { models: { text, inputRef, focusedInputIndex }, actions: { clear, handlePress, handleTextChange }, forms: { setTextWithRef } } = (0, useOtpInput_1.useOtpInput)(props);
-    const { numberOfDigits, hideStick, focusColor = "#A4D0A4", focusStickBlinkingDuration, theme = {}, } = props;
+    const { models: { text, inputRef, focusedInputIndex }, actions: { clear, handlePress, handleTextChange }, forms: { setTextWithRef }, } = (0, useOtpInput_1.useOtpInput)(props);
+    const { numberOfDigits, hideStick, focusColor = "#A4D0A4", focusStickBlinkingDuration, secureTextEntry = false, theme = {}, } = props;
     const { containerStyle, inputsContainerStyle, pinCodeContainerStyle, pinCodeTextStyle, focusStickStyle, } = theme;
     (0, react_1.useImperativeHandle)(ref, () => ({ clear, setValue: setTextWithRef }));
     return (<react_native_1.View style={[OtpInput_styles_1.styles.container, containerStyle]}>
@@ -23,10 +23,12 @@ exports.OtpInput = (0, react_1.forwardRef)((props, ref) => {
                     pinCodeContainerStyle,
                     focusColor && isFocusedInput ? { borderColor: focusColor } : {},
                 ]} testID="otp-input">
-                {isFocusedInput && !hideStick ? (<VerticalStick_1.VerticalStick focusColor={focusColor} style={focusStickStyle} focusStickBlinkingDuration={focusStickBlinkingDuration}/>) : (<react_native_1.Text style={[OtpInput_styles_1.styles.codeText, pinCodeTextStyle]}>{char}</react_native_1.Text>)}
+                {isFocusedInput && !hideStick ? (<VerticalStick_1.VerticalStick focusColor={focusColor} style={focusStickStyle} focusStickBlinkingDuration={focusStickBlinkingDuration}/>) : (<react_native_1.Text style={[OtpInput_styles_1.styles.codeText, pinCodeTextStyle]}>
+                    {char && secureTextEntry ? "•" : char}
+                  </react_native_1.Text>)}
               </react_native_1.Pressable>);
         })}
       </react_native_1.View>
-      <react_native_1.TextInput value={text} onChangeText={handleTextChange} maxLength={numberOfDigits} inputMode="numeric" ref={inputRef} autoFocus style={OtpInput_styles_1.styles.hiddenInput} testID="otp-input-hidden"/>
+      <react_native_1.TextInput value={text} onChangeText={handleTextChange} maxLength={numberOfDigits} inputMode="numeric" ref={inputRef} autoFocus style={OtpInput_styles_1.styles.hiddenInput} secureTextEntry={secureTextEntry} testID="otp-input-hidden"/>
     </react_native_1.View>);
 });

--- a/dist/src/OtpInput/OtpInput.test.js
+++ b/dist/src/OtpInput/OtpInput.test.js
@@ -15,6 +15,15 @@ describe("OtpInput", () => {
             const stick = react_native_1.screen.getByTestId("otp-input-stick");
             expect(stick).toBeTruthy();
         });
+        test('should not show values if "secureTextEntry" is true', () => {
+            renderOtpInput({ secureTextEntry: true });
+            const input = react_native_1.screen.getByTestId("otp-input-hidden");
+            react_native_1.fireEvent.changeText(input, "123456");
+            const inputs = react_native_1.screen.getAllByTestId("otp-input");
+            inputs.forEach((input) => {
+                expect(input).toHaveTextContent("•");
+            });
+        });
         test("focusColor should not be overridden by theme", () => {
             renderOtpInput({
                 focusColor: "#000",

--- a/dist/src/OtpInput/OtpInput.types.d.ts
+++ b/dist/src/OtpInput/OtpInput.types.d.ts
@@ -6,6 +6,7 @@ export interface OtpInputProps {
     onFilled?: (text: string) => void;
     hideStick?: boolean;
     focusStickBlinkingDuration?: number;
+    secureTextEntry?: boolean;
     theme?: Theme;
 }
 export interface OtpInputRef {

--- a/src/OtpInput/OtpInput.test.tsx
+++ b/src/OtpInput/OtpInput.test.tsx
@@ -22,6 +22,18 @@ describe("OtpInput", () => {
       expect(stick).toBeTruthy();
     });
 
+    test('should not show values if "secureTextEntry" is true', () => {
+      renderOtpInput({ secureTextEntry: true });
+
+      const input = screen.getByTestId("otp-input-hidden");
+      fireEvent.changeText(input, "123456");
+      const inputs = screen.getAllByTestId("otp-input");
+
+      inputs.forEach((input) => {
+        expect(input).toHaveTextContent("•");
+      });
+    });
+
     test("focusColor should not be overridden by theme", () => {
       renderOtpInput({
         focusColor: "#000",

--- a/src/OtpInput/OtpInput.tsx
+++ b/src/OtpInput/OtpInput.tsx
@@ -9,7 +9,7 @@ export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props, ref) => {
   const {
     models: { text, inputRef, focusedInputIndex },
     actions: { clear, handlePress, handleTextChange },
-    forms: {setTextWithRef}
+    forms: { setTextWithRef },
   } = useOtpInput(props);
   const {
     numberOfDigits,
@@ -56,7 +56,9 @@ export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props, ref) => {
                     focusStickBlinkingDuration={focusStickBlinkingDuration}
                   />
                 ) : (
-                  <Text style={[styles.codeText, pinCodeTextStyle]}>{char && secureTextEntry ? "•" : char}</Text>
+                  <Text style={[styles.codeText, pinCodeTextStyle]}>
+                    {char && secureTextEntry ? "•" : char}
+                  </Text>
                 )}
               </Pressable>
             );
@@ -70,6 +72,7 @@ export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props, ref) => {
         ref={inputRef}
         autoFocus
         style={styles.hiddenInput}
+        secureTextEntry={secureTextEntry}
         testID="otp-input-hidden"
       />
     </View>

--- a/src/OtpInput/OtpInput.tsx
+++ b/src/OtpInput/OtpInput.tsx
@@ -16,6 +16,7 @@ export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props, ref) => {
     hideStick,
     focusColor = "#A4D0A4",
     focusStickBlinkingDuration,
+    secureTextEntry = false,
     theme = {},
   } = props;
   const {
@@ -55,7 +56,7 @@ export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props, ref) => {
                     focusStickBlinkingDuration={focusStickBlinkingDuration}
                   />
                 ) : (
-                  <Text style={[styles.codeText, pinCodeTextStyle]}>{char}</Text>
+                  <Text style={[styles.codeText, pinCodeTextStyle]}>{char && secureTextEntry ? "•" : char}</Text>
                 )}
               </Pressable>
             );

--- a/src/OtpInput/OtpInput.types.ts
+++ b/src/OtpInput/OtpInput.types.ts
@@ -7,6 +7,7 @@ export interface OtpInputProps {
   onFilled?: (text: string) => void;
   hideStick?: boolean;
   focusStickBlinkingDuration?: number;
+  secureTextEntry?: boolean;
   theme?: Theme;
 }
 

--- a/src/OtpInput/__snapshots__/OtpInput.test.tsx.snap
+++ b/src/OtpInput/__snapshots__/OtpInput.test.tsx.snap
@@ -394,6 +394,7 @@ exports[`OtpInput UI should render correctly 1`] = `
     inputMode="numeric"
     maxLength={6}
     onChangeText={[Function]}
+    secureTextEntry={false}
     style={
       {
         "height": 1,


### PR DESCRIPTION
### Description
`secureTextEntry` forces UI to display dots instead of OTP code to secure it.