### PR TITLE
feat: implement blur on fill

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -84,14 +84,15 @@ The `react-native-otp-entry` component accepts the following props:
 | ---------------------------- | ---------------------- | -------------------------------------------------------------------------------------------------------------- |
 | `numberOfDigits`             | number                 | The number of digits to be displayed in the OTP entry.                                                         |
 | `textInputProps`             | TextInputProps         | Extra props passed to underlying hidden TextInput (see: https://reactnative.dev/docs/textinput)                |
-| `autoFocus`                  | boolean                | Default: true. Set autofocus.                                                                                  |
+| `autoFocus`                  | boolean                | _Default: true_. Sets autofocus.                                                                               |
 | `focusColor`                 | ColorValue             | The color of the input field border and stick when it is focused.                                              |
 | `onTextChange`               | (text: string) => void | A callback function is invoked when the OTP text changes. It receives the updated text as an argument.         |
 | `onFilled`                   | (text: string) => void | A callback function is invoked when the OTP input is fully filled. It receives a full otp code as an argument. |
-| `hideStick`                  | boolean                | Hide cursor of the focused input.                                                                              |
+| `blurOnFilled`               | boolean                | _Default: false_. Blurs (unfocuses) the input when the OTP input is fully filled.                              |
+| `hideStick`                  | boolean                | _Default: false_. Hides cursor of the focused input.                                                           |
 | `theme`                      | Theme                  | Custom styles for each element.                                                                                |
 | `focusStickBlinkingDuration` | number                 | The duration (in milliseconds) for the focus stick to blink.                                                   |
-| `disabled`                   | boolean                | Default: false. Disable the input                                                                              |
+| `disabled`                   | boolean                | _Default: false_. Disables the input                                                                           |
 
 | Theme                           | Type      | Description                                                                        |
 | ------------------------------- | --------- | ---------------------------------------------------------------------------------- |

--- a/src/OtpInput/OtpInput.tsx
+++ b/src/OtpInput/OtpInput.tsx
@@ -65,7 +65,7 @@ export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props, ref) => {
             const char = text[index];
             const isFocusedInput = index === focusedInputIndex && !disabled && Boolean(isFocused);
             const isFilledLastInput = text.length === numberOfDigits && index === text.length - 1;
-            const isFocusedContainer = isFocusedInput || (isFilledLastInput && Boolean(isFocused))
+            const isFocusedContainer = isFocusedInput || (isFilledLastInput && Boolean(isFocused));
 
             return (
               <Pressable

--- a/src/OtpInput/OtpInput.types.ts
+++ b/src/OtpInput/OtpInput.types.ts
@@ -6,6 +6,7 @@ export interface OtpInputProps {
   focusColor?: ColorValue;
   onTextChange?: (text: string) => void;
   onFilled?: (text: string) => void;
+  blurOnFilled?: boolean;
   hideStick?: boolean;
   focusStickBlinkingDuration?: number;
   secureTextEntry?: boolean;

--- a/src/OtpInput/__tests__/useOtpInput.test.ts
+++ b/src/OtpInput/__tests__/useOtpInput.test.ts
@@ -153,6 +153,7 @@ describe("useOtpInput", () => {
       expect(mockSetState).toHaveBeenCalledWith(true);
     });
   });
+
   test("handleBlur() should set hasCurrentFocus to false", () => {
     const mockSetState = jest.fn();
     jest.spyOn(React, "useState").mockImplementation(() => [true, mockSetState]);
@@ -161,6 +162,28 @@ describe("useOtpInput", () => {
 
     act(() => {
       expect(mockSetState).toHaveBeenCalledWith(false);
+    });
+  });
+
+  test("should blur the input when filled if blurOnFilled is 'true'", () => {
+    jest.spyOn(React, "useRef").mockReturnValue({ current: { blur: jest.fn() } } as any);
+
+    const { result } = renderUseOtInput({ blurOnFilled: true });
+    result.current.actions.handleTextChange("123456");
+
+    act(() => {
+      expect(result.current.models.inputRef.current?.blur).toHaveBeenCalled();
+    });
+  });
+
+  test("should NOT blur the input when filled if blurOnFilled is 'true'", () => {
+    jest.spyOn(React, "useRef").mockReturnValue({ current: { blur: jest.fn() } } as any);
+
+    const { result } = renderUseOtInput();
+    result.current.actions.handleTextChange("123456");
+
+    act(() => {
+      expect(result.current.models.inputRef.current?.blur).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/OtpInput/useOtpInput.ts
+++ b/src/OtpInput/useOtpInput.ts
@@ -8,6 +8,7 @@ export const useOtpInput = ({
   numberOfDigits = 6,
   disabled,
   autoFocus = true,
+  blurOnFilled,
 }: OtpInputProps) => {
   const [text, setText] = useState("");
   const [isFocused, setIsFocused] = useState(autoFocus);
@@ -28,6 +29,7 @@ export const useOtpInput = ({
     onTextChange?.(value);
     if (value.length === numberOfDigits) {
       onFilled?.(value);
+      blurOnFilled && inputRef.current?.blur();
     }
   };
 


### PR DESCRIPTION
## Closes #59 

# Description
Added a new prop `blurOnFilled`, when `true` it automatically blurs the input and hides the keyboard on fill.
Default value is `false`

# Demo
![Simulator Screen Recording - iPhone 15 Pro Max - 2024-05-27 at 11 13 16](https://github.com/anday013/react-native-otp-entry/assets/48630069/c30d6868-b780-496d-991d-98594dfa3e28)
