### PR TITLE
style: fix hidden input opactiy

### DIFF
--- a/src/OtpInput/OtpInput.styles.ts
+++ b/src/OtpInput/OtpInput.styles.ts
@@ -20,7 +20,7 @@ export const styles = StyleSheet.create({
   },
   hiddenInput: {
     ...StyleSheet.absoluteFillObject,
-    opacity: 0.01,
+    opacity: 0,
   },
   stick: {
     width: 2,

--- a/src/OtpInput/__tests__/__snapshots__/OtpInput.test.tsx.snap
+++ b/src/OtpInput/__tests__/__snapshots__/OtpInput.test.tsx.snap
@@ -390,7 +390,7 @@ exports[`OtpInput UI should render correctly 1`] = `
         {
           "bottom": 0,
           "left": 0,
-          "opacity": 0.01,
+          "opacity": 0,
           "position": "absolute",
           "right": 0,
           "top": 0,


### PR DESCRIPTION
When the OTP input is focused, the base input, which should be hidden, is faintly visible. If you zoom in, you can notice it. I'm not sure if it was intentional to set the opacity to 0.01, but I fixed it by setting the opacity to 0 so that the input doesn't appear at all.

![opacity](https://github.com/anday013/react-native-otp-entry/assets/92739298/4bd08712-da64-416b-b9de-e073a9381206)

@anday013