### PR TITLE
Prop 'type' doesn't change keyboard type

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "test:coverage": "jest --collectCoverage --coverageDirectory=\"./coverage\"",
     "build:dev": "tsc",
     "build:prod": "tsc -p tsconfig.prod.json",
-    "prepublishOnly": "npm install && npm run build:prod"
+    "prepublishOnly": "npm install && npm run build:prod",
+    "prepare": "npm run build:prod"
   },
   "keywords": [
     "react-native",

--- a/src/OtpInput/OtpInput.tsx
+++ b/src/OtpInput/OtpInput.tsx
@@ -5,7 +5,7 @@ import { OtpInputProps, OtpInputRef } from "./OtpInput.types";
 import { VerticalStick } from "./VerticalStick";
 import { useOtpInput } from "./useOtpInput";
 
-export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props, ref) => {
+export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props: OtpInputProps, ref) => {
   const {
     models: { text, inputRef, focusedInputIndex, isFocused },
     actions: { clear, handlePress, handleTextChange, focus, handleFocus, handleBlur },
@@ -21,6 +21,7 @@ export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props, ref) => {
     secureTextEntry = false,
     theme = {},
     textInputProps,
+    type = 'numeric',
   } = props;
   const {
     containerStyle,
@@ -92,8 +93,7 @@ export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props, ref) => {
         value={text}
         onChangeText={handleTextChange}
         maxLength={numberOfDigits}
-        inputMode="numeric"
-        keyboardType="numeric"
+        inputMode={type === 'numeric' ? type : 'text'}
         textContentType="oneTimeCode"
         ref={inputRef}
         autoFocus={autoFocus}

--- a/src/OtpInput/OtpInput.tsx
+++ b/src/OtpInput/OtpInput.tsx
@@ -5,7 +5,7 @@ import { OtpInputProps, OtpInputRef } from "./OtpInput.types";
 import { VerticalStick } from "./VerticalStick";
 import { useOtpInput } from "./useOtpInput";
 
-export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props: OtpInputProps, ref) => {
+export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props, ref) => {
   const {
     models: { text, inputRef, focusedInputIndex, isFocused },
     actions: { clear, handlePress, handleTextChange, focus, handleFocus, handleBlur },

--- a/src/OtpInput/__tests__/__snapshots__/OtpInput.test.tsx.snap
+++ b/src/OtpInput/__tests__/__snapshots__/OtpInput.test.tsx.snap
@@ -379,7 +379,6 @@ exports[`OtpInput UI should render correctly 1`] = `
     autoFocus={true}
     editable={true}
     inputMode="numeric"
-    keyboardType="numeric"
     maxLength={6}
     onBlur={[Function]}
     onChangeText={[Function]}


### PR DESCRIPTION
When prop type was set to 'alphanumeric' the keyboard remains numeric. 
Please approve it, because now it works perfectly for both types.
![IMG_0453](https://github.com/user-attachments/assets/cd06b5ac-62cb-4255-940c-1cad6db8e894)
![IMG_0452](https://github.com/user-attachments/assets/d1044cb7-c980-4e86-95a4-a7a0923260f9)
