### PR TITLE
docs: add secureTextEntry to Props

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -94,6 +94,7 @@ The `react-native-otp-entry` component accepts the following props:
 | `focusStickBlinkingDuration` | number                                 | The duration (in milliseconds) for the focus stick to blink.                                                   |
 | `disabled`                   | boolean                                | _Default: false_. Disables the input                                                                           |
 | `type`                       | 'alpha' \| 'numeric' \| 'alphanumeric' | The type of input. 'alpha': letters only, 'numeric': numbers only, 'alphanumeric': letters or numbers.         |
+| `secureTextEntry`            | boolean                                | _Default: false_. Obscures the text entered so that sensitive text like PIN stay secure.                       |
 
 | Theme                           | Type      | Description                                                                        |
 | ------------------------------- | --------- | ---------------------------------------------------------------------------------- |


### PR DESCRIPTION
This morning, just stumble into my coworker that does not aware this packages support `secureTextEntry` props. This PR add this to the props doc. Feel free to accept/drop this PR, thanks for this great package!
