### PR TITLE
feat: add accessibilityLabel otp-input

### DIFF
--- a/src/OtpInput/OtpInput.tsx
+++ b/src/OtpInput/OtpInput.tsx
@@ -73,6 +73,7 @@ export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props, ref) => {
               onPress={handlePress}
               style={generatePinCodeContainerStyle(isFocusedContainer, char)}
               testID="otp-input"
+              accessibilityLabel="otp-input"
             >
               {isFocusedInput && !hideStick ? (
                 <VerticalStick


### PR DESCRIPTION
This pull request adds an **accessibilityLabel** prop to the **Pressable** component within the **OtpInput** component. The change is minimal but significantly enhances the testability of the component across both Android and iOS platforms when using automated testing tools like Appium.

Changes Made:

Added **accessibilityLabel="otp-input"** to the **Pressable** component in **OtpInput.tsx**.
Reason for Change:

While using Appium for end-to-end testing, I encountered difficulties locating the **OtpInput** element on Android devices. The **testID** prop in React Native maps to **resource-id** on Android, which requires the package name prefix to be correctly located. This can lead to inconsistencies and complexities in test scripts, especially when the package name might differ across environments or when using cloud-based testing platforms like **BrowserStack**.

By adding the **accessibilityLabel** prop:

On Android, it sets the **content-desc** attribute, allowing the element to be located using the **accessibility id** locator strategy in Appium.
On iOS, it maps to **accessibilityIdentifier**, which is also accessible via the **accessibility id** strategy.