### PR TITLE
fix: support RN 0.85 hidden input absolute fill behavior

### DIFF
--- a/src/OtpInput/OtpInput.styles.ts
+++ b/src/OtpInput/OtpInput.styles.ts
@@ -19,7 +19,6 @@ export const styles = StyleSheet.create({
     fontSize: 28,
   },
   hiddenInput: {
-    ...StyleSheet.absoluteFillObject,
     ...Platform.select({
       ios: {
         opacity: 0.02,

--- a/src/OtpInput/OtpInput.tsx
+++ b/src/OtpInput/OtpInput.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import { forwardRef, useImperativeHandle } from "react";
-import { Platform, Pressable, Text, TextInput, View } from "react-native";
+import { Platform, Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 import { styles } from "./OtpInput.styles";
 import { OtpInputProps, OtpInputRef } from "./OtpInput.types";
 import { VerticalStick } from "./VerticalStick";
@@ -124,7 +124,7 @@ export const OtpInput = forwardRef<OtpInputRef, OtpInputProps>((props, ref) => {
         onBlur={handleBlur}
         caretHidden={Platform.OS === "ios"}
         {...textInputProps}
-        style={[styles.hiddenInput, textInputProps?.style]}
+        style={[StyleSheet.absoluteFill, styles.hiddenInput, textInputProps?.style]}
       />
     </View>
   );

--- a/src/OtpInput/__tests__/OtpInput.test.tsx
+++ b/src/OtpInput/__tests__/OtpInput.test.tsx
@@ -73,6 +73,20 @@ describe("OtpInput", () => {
       expect(input.props.autoFocus).toBe(false);
     });
 
+    test("should keep hidden input absolutely positioned to avoid affecting OTP cell spacing", () => {
+      renderOtpInput();
+
+      const input = screen.getByTestId("otp-input-hidden");
+
+      expect(input).toHaveStyle({
+        position: "absolute",
+        top: 0,
+        right: 0,
+        bottom: 0,
+        left: 0,
+      });
+    });
+
     test("should not focus if disabled is true", () => {
       renderOtpInput({
         disabled: true,

--- a/src/OtpInput/__tests__/__snapshots__/OtpInput.test.tsx.snap
+++ b/src/OtpInput/__tests__/__snapshots__/OtpInput.test.tsx.snap
@@ -399,12 +399,14 @@ exports[`OtpInput UI should render correctly 1`] = `
       [
         {
           "bottom": 0,
-          "color": "transparent",
           "left": 0,
-          "opacity": 0.02,
           "position": "absolute",
           "right": 0,
           "top": 0,
+        },
+        {
+          "color": "transparent",
+          "opacity": 0.02,
         },
         undefined,
       ]


### PR DESCRIPTION
### Motivation
- React Native 0.85 deprecated `StyleSheet.absoluteFillObject` which caused the OTP hidden `TextInput` to affect layout and make OTP cells move when filled.
- The fix must be applied in the source styles (not only `dist`) so all consumers get the RN 0.85-compatible behavior.

### Description
- Remove `...StyleSheet.absoluteFillObject` from `hiddenInput` in `src/OtpInput/OtpInput.styles.ts` and keep only the platform-visibility rules (`opacity`/`color`).
- Apply `StyleSheet.absoluteFill` directly in the rendered `TextInput` style array in `src/OtpInput/OtpInput.tsx` via `style={[StyleSheet.absoluteFill, styles.hiddenInput, textInputProps?.style]}` to ensure absolute overlay behavior on RN 0.85.
- Add a minimal regression test in `src/OtpInput/__tests__/OtpInput.test.tsx` that asserts the hidden input has absolute positioning and thus cannot affect OTP cell spacing, and update the snapshot accordingly.
- Regenerated build artifacts via the project `tsc` build so the produced `dist` output matches the source change.
- This change closes issue #116.

### Testing
- Ran `npm test -- --runInBand -u` and all tests passed with the snapshot updated successfully.
- Ran `npm run ts:check` (`tsc --noEmit`) and it completed without errors.
- Ran `npm run build:prod` (`tsc -p tsconfig.prod.json`) and the production build completed successfully.
- Verified there are no remaining `absoluteFillObject` occurrences in `src` or `dist` after the change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_69eca7cb845483218453c58d354ce57d)